### PR TITLE
Modify OverlayImage to retain OpenCV 3 and 4 compatability

### DIFF
--- a/include/sonar_image_proc/OverlayImage.h
+++ b/include/sonar_image_proc/OverlayImage.h
@@ -20,8 +20,13 @@ void overlayImage(const Mat &bg, const Mat &fg, Mat &dst) {
   const float alpha_scale = (float)std::numeric_limits<T>::max(),
               inv_scale = 1.f / alpha_scale;
 
+  #if (CV_VERSION_MAJOR >= 4)
   CV_Assert(bg.type() == cv::traits::Type<VB>::value &&
             fg.type() == cv::traits::Type<VF>::value && bg.size() == fg.size());
+  #else
+  CV_Assert(bg.type() == cv::DataType<VB>::type &&
+            fg.type() == cv::DataType<VF>::type && bg.size() == fg.size());  
+  #endif
 
   dst.create(bg.size(), bg.type());
 


### PR DESCRIPTION
Minor change is needed in OverlayImage to retain compatibility with OpenCV3, since there is a deprecation in type trait functions between v3 and v4.