### PR TITLE
Publish Sonar FOV as Marker for rviz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ build/
 
 .fips-*
 .history/*
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ build/
 *.app
 
 .fips-*
+.history/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(sonar_image_proc)
 
-if( FIPS_CONFIG AND NOT FIPS_IMPORT )
+if(FIPS_CONFIG AND NOT FIPS_IMPORT)
   cmake_minimum_required(VERSION 3.5)
 
   get_filename_component(FIPS_ROOT_DIR "../fips" ABSOLUTE)
@@ -15,43 +15,39 @@ endif()
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 # find_package(Eigen3 REQUIRED )
-find_package(Boost COMPONENTS filesystem system program_options REQUIRED )
+find_package(Boost COMPONENTS filesystem system program_options REQUIRED)
 
-## Default OpenCV version
-list(APPEND OPENCV_COMPONENTS core highgui imgproc )
+# # Default OpenCV version
+list(APPEND OPENCV_COMPONENTS core highgui imgproc)
 find_package(OpenCV COMPONENTS ${OPENCV_COMPONENTS} REQUIRED)
 
-
-if( FIPS_CONFIG )
-
-  ## Set global include paths
+if(FIPS_CONFIG)
+  # # Set global include paths
   fips_include_directories(
     ${CMAKE_SOURCE_DIR}/include
     ${OpenCV_INCLUDE_DIRS}
-   )
+  )
 
   # The local library
-  fips_begin_module( sonar_image_proc )
+  fips_begin_module(sonar_image_proc)
 
-    fips_src( lib *.cpp )
-    fips_libs( ${Boost_LIBRARIES} ${OpenCV_LIBS} )
+  fips_src(lib *.cpp)
+  fips_libs(${Boost_LIBRARIES} ${OpenCV_LIBS})
 
   fips_end_module()
 
-  if( NOT FIPS_IMPORT )
-
-    if( FIPS_UNITTESTS )
-      gtest_begin( sonar_image_proc )
-        fips_src( test/unit/ )
-        fips_deps( sonar_image_proc )
+  if(NOT FIPS_IMPORT)
+    if(FIPS_UNITTESTS)
+      gtest_begin(sonar_image_proc)
+      fips_src(test/unit/)
+      fips_deps(sonar_image_proc)
       gtest_end()
     endif()
-
   endif()
+
   fips_finish()
 
 else()
-
   find_package(catkin REQUIRED
     acoustic_msgs
     cv_bridge
@@ -68,26 +64,26 @@ else()
   )
 
   catkin_package(
-      INCLUDE_DIRS include/ ros/include/
-      LIBRARIES sonar_image_proc
-      DEPENDS OpenCV
-      #CATKIN_DEPENDS 
-  )
+    INCLUDE_DIRS include/ ros/include/
+    LIBRARIES sonar_image_proc
+    DEPENDS OpenCV
 
+    # CATKIN_DEPENDS
+  )
 
   include_directories(
     include/
     ros/include/
     ${catkin_INCLUDE_DIRS}
     ${OpenCV_INCLUDE_DIRS}
- )
+  )
 
   set(sonar_image_proc_SRCS
-      lib/AbstractSonarInterface.cpp
-   	  lib/ColorMaps.cpp
-      lib/SonarDrawer.cpp
-      lib/OldDrawSonar.cpp
-      lib/HistogramGenerator.cpp
+    lib/AbstractSonarInterface.cpp
+    lib/ColorMaps.cpp
+    lib/SonarDrawer.cpp
+    lib/OldDrawSonar.cpp
+    lib/HistogramGenerator.cpp
   )
 
   # "true" library containing core functionality
@@ -98,23 +94,23 @@ else()
 
   # Dynamically loadable libraries containing nodelets
   add_library(sonar_image_proc_nodelets
-                ros/src/draw_sonar_nodelet.cpp
-                ros/src/sonar_postprocessor_nodelet.cpp)
-  target_link_libraries(sonar_image_proc_nodelets ${catkin_LIBRARIES} sonar_image_proc )
+    ros/src/draw_sonar_nodelet.cpp
+    ros/src/sonar_postprocessor_nodelet.cpp)
+  target_link_libraries(sonar_image_proc_nodelets ${catkin_LIBRARIES} sonar_image_proc)
   set_property(TARGET sonar_image_proc_nodelets PROPERTY CXX_STANDARD 14)
 
-  ## Standalone nodes
+  # # Standalone nodes
   add_executable(draw_sonar_node ros/src/draw_sonar_node.cpp)
   target_link_libraries(draw_sonar_node
-     sonar_image_proc
-     ${catkin_LIBRARIES})
+    sonar_image_proc
+    ${catkin_LIBRARIES})
   add_dependencies(draw_sonar_node ${catkin_EXPORTED_TARGETS})
   set_property(TARGET draw_sonar_node PROPERTY CXX_STANDARD 14)
 
   add_executable(sonar_postprocessor_node ros/src/sonar_postprocessor_node.cpp)
   target_link_libraries(sonar_postprocessor_node
-     sonar_image_proc
-     ${catkin_LIBRARIES})
+    sonar_image_proc
+    ${catkin_LIBRARIES})
   add_dependencies(sonar_postprocessor_node ${catkin_EXPORTED_TARGETS})
   set_property(TARGET sonar_postprocessor_node PROPERTY CXX_STANDARD 14)
 
@@ -122,44 +118,44 @@ else()
   # executable which uses ros_storage to read ros bags
   add_executable(bag2sonar ros/tools/bag2sonar.cpp)
   target_link_libraries(bag2sonar
-     sonar_image_proc
-     ${catkin_LIBRARIES})
+    sonar_image_proc
+    ${catkin_LIBRARIES})
   add_dependencies(bag2sonar ${catkin_EXPORTED_TARGETS})
   set_property(TARGET bag2sonar PROPERTY CXX_STANDARD 14)
 
   install(TARGETS draw_sonar_node
-              sonar_postprocessor_node
-              bag2sonar
-         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+    sonar_postprocessor_node
+    bag2sonar
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
   install(TARGETS
-              sonar_image_proc_nodelets
-              sonar_image_proc
-         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+    sonar_image_proc_nodelets
+    sonar_image_proc
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
-	install( DIRECTORY launch/
-	        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch )
+  install(DIRECTORY launch/
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)
 
-#	install( DIRECTORY rqt_config/
-#	        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/rqt_config )
-
+  # install( DIRECTORY rqt_config/
+  # DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/rqt_config )
   install(FILES nodelet_plugins.xml
-   		   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
-  ## Install headers
-  install(DIRECTORY  include/${PROJECT_NAME}/
-      DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-      FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h"
-      PATTERN ".git" EXCLUDE)
+  # # Install headers
+  install(DIRECTORY include/${PROJECT_NAME}/
+    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+    FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h"
+    PATTERN ".git" EXCLUDE)
 
   catkin_install_python(PROGRAMS
     scripts/sonar_pointcloud.py
+    scripts/sonar_fov.py
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   )
 
-  ## Disable python wrapper for now ...
+  # # Disable python wrapper for now ...
   #
-  ## == Stuff related to the Python wrapper ==
+  # # == Stuff related to the Python wrapper ==
   # pybind_add_module(py_draw_sonar SHARED
   # python/py_draw_sonar.cpp
   # python/ndarray_converter.cpp
@@ -173,5 +169,4 @@ else()
   # DESTINATION ${CATKIN_GLOBAL_PYTHON_DESTINATION} ) #${CATKIN_PACKAGE_PYTHON_DESTINATION})
 
   # catkin_python_setup()
-
 endif()

--- a/scripts/sonar_fov.py
+++ b/scripts/sonar_fov.py
@@ -1,0 +1,222 @@
+#! /usr/bin/env python3
+import os
+import rospy
+import time
+import rospkg
+
+import numpy as np
+import open3d as o3d
+
+from stl import mesh
+from std_srvs.srv import Empty
+from std_msgs.msg import Header, Float32
+from acoustic_msgs.msg import ProjectedSonarImage, SonarImageData, PingInfo
+from sensor_msgs.msg import PointCloud2, PointField
+from visualization_msgs.msg import Marker, MarkerArray
+
+
+r = rospkg.RosPack()
+path = r.get_path('sonar_image_proc')
+stl_name = "sonar_fov.stl"
+temp_mesh_file = os.path.join(path, "scripts", stl_name)
+
+
+def sonar_params(image_msg):
+
+    param_dict = {}
+    ranges = image_msg.ranges
+    azimuth_ranges = [image_msg.beam_directions[0].y,
+                      image_msg.beam_directions[-1].y]
+
+    azimuth_start = min(azimuth_ranges)
+    azimuth_end = max(azimuth_ranges)
+    num_azimuth_steps = len(image_msg.beam_directions)
+
+    azimuth_steps = np.linspace(
+        azimuth_start, azimuth_end, num_azimuth_steps)
+    azimuth_steps[azimuth_steps < 0] += 2*np.pi
+
+    elevation_ranges = [beam_dir.z for beam_dir in image_msg.beam_directions]
+    elevation_start = np.arccos(max(elevation_ranges))
+    elevation_end = np.arccos(min(elevation_ranges))
+
+    print(elevation_start, elevation_end)
+    elevation_steps = 2
+    elevations = np.linspace(
+        elevation_start, elevation_end, elevation_steps)
+    elevations = elevations + np.pi/2
+
+    param_dict['range'] = max(ranges)
+    param_dict['elevations'] = elevations
+    param_dict['azimuth_steps'] = azimuth_steps
+    return param_dict
+
+
+def build_stl_mesh(params):
+    """
+    From sonar parameters, build the wedge
+    Save it in a temp file that gets removed after each run (or if parameters change mid-run)
+    """
+    global temp_mesh_file
+
+    xx = []
+    yy = []
+    zz = []
+
+    # Calculate points in 3d space
+    for elevation in params['elevations']:
+        x = params['range'] * np.sin(elevation) * \
+            np.cos(params['azimuth_steps'])
+        y = params['range'] * np.sin(elevation) * \
+            np.sin(params['azimuth_steps'])
+        z = np.full_like(x, fill_value=params['range']*np.cos(elevation))
+        xx.extend(x)
+        yy.extend(y)
+        zz.extend(z)
+
+    xx_new = np.insert(np.array(xx), 0, 0)
+    yy_new = np.insert(np.array(yy), 0, 0)
+    zz_new = np.insert(np.array(zz), 0, 0)
+
+    vertices = np.zeros(shape=(len(xx_new), 3))
+    vertices[:, 0] = xx_new
+    vertices[:, 1] = yy_new
+    vertices[:, 2] = zz_new
+
+    # First, connect all the wedges on each face:
+    split = (len(xx_new) - 1)//2
+    first_pt = np.zeros(shape=(len(xx_new) - 2), dtype=np.uint)
+    second_pt = np.arange(1, len(xx_new) - 1, dtype=np.uint)
+    third_pt = np.arange(2, len(xx_new), dtype=np.uint)
+    first_faces = np.stack([first_pt, second_pt, third_pt]).T
+
+    # Delete the cross-over wedge:
+    first_faces = np.delete(first_faces, (split - 1), axis=0)
+
+    # Add triangles between elevations:
+    first_pt = np.arange(1, split, dtype=np.uint)
+    second_pt = first_pt + 1
+    third_pt = second_pt + split - 1
+    fourth_pt = third_pt + 1
+
+    first_connection = np.stack([first_pt, second_pt, third_pt]).T
+    second_connection = np.stack([second_pt, third_pt, fourth_pt]).T
+    second_faces = np.vstack([first_connection, second_connection])
+
+    faces = np.vstack([first_faces, second_faces])
+
+    # Add triangles on sides:
+    side_faces = np.array([[0, 1, split + 1],
+                           [0, split, (len(xx_new) - 1)]], dtype=np.uint)
+
+    faces = np.vstack([faces, side_faces])
+
+    # Create the mesh
+    wedge = mesh.Mesh(np.zeros(faces.shape[0], dtype=mesh.Mesh.dtype))
+    for i, f in enumerate(faces):
+        for j in range(3):
+            wedge.vectors[i][j] = vertices[f[j], :]
+
+    # Write the mesh to file
+    wedge.save(temp_mesh_file)
+    print(f"Saving fov to {temp_mesh_file}")
+
+
+def clean_up_mesh():
+    """
+    Delete temporary mesh file when program closes
+    """
+    global temp_mesh_file
+    os.remove(temp_mesh_file)
+
+
+class SonarFOV():
+
+    def __init__(self):
+        # NB: if queue_size is set, have to be sure buff_size is sufficiently large,
+        #     since it can only discard messages that are fully in the buffer.
+        # https://stackoverflow.com/questions/26415699/ros-subscriber-not-up-to-date
+        # (200k didn't work, and sys.getsizeof doesn't return an accurate size of the whole object)
+        self.sub = rospy.Subscriber("sonar_image",
+                                    ProjectedSonarImage,
+                                    self.callback,
+                                    queue_size=1,
+                                    buff_size=1000000)
+        self.pub_fov = rospy.Publisher('/sonar_fov',
+                                       MarkerArray,
+                                       queue_size=10)
+
+        self.generate_fov = False
+        self.sonar_params = None
+
+    def generate_marker_array(self):
+        # This is the FOV object
+        global stl_name
+
+        obj = Marker()
+        obj.type = Marker.MESH_RESOURCE
+        obj.id = 1
+        obj.mesh_resource = f"package://sonar_image_proc/scripts/{stl_name}"
+        obj.frame_locked = True
+
+        # obj.pose.position.x = 0
+        # obj.pose.position.y = 0
+        # obj.pose.position.z = 0
+        # obj.pose.orientation.y = 0
+        # obj.pose.orientation.w = 0
+
+        obj.scale.x = 1.0
+        obj.scale.y = 1.0
+        obj.scale.z = 1.0
+
+        obj.color.r = 1.0
+        obj.color.g = 1.0
+        obj.color.b = 1.0
+        obj.color.a = 1.0
+
+        self.world = MarkerArray()
+        self.world.markers = [obj]
+
+    def callback(self, image_msg: ProjectedSonarImage):
+        """
+        Generate FOV wedge based on parameters
+        """
+        rospy.logdebug("Received new image, seq %d at %f" %
+                       (image_msg.header.seq, image_msg.header.stamp.to_sec()))
+
+        if self.sonar_params is None:
+            self.sonar_params = sonar_params(image_msg)
+            self.generate_fov_flag = True  # generate the fov stl
+        else:
+            new_params = sonar_params(image_msg)
+            dict_equality = np.all([np.all(self.sonar_params[key] == new_params[key])
+                                   for key in self.sonar_params.keys()])
+            if not dict_equality:
+                rospy.logdebug("Updating Parameters of FOV")
+                self.generate_fov_flag = True  # generate the fov stl
+            else:
+                self.generate_fov_flag = False  # no need to generate the fov stl
+
+        if self.generate_fov_flag:
+            rospy.logdebug("Generating FOV mesh")
+            build_stl_mesh(self.sonar_params)
+
+        header = Header()
+        header = image_msg.header
+
+        frame_id = rospy.get_param("~frame_id", None)
+        if frame_id:
+            header.frame_id = frame_id
+
+        self.generate_marker_array()
+        for obj in self.world.markers:
+            obj.header = image_msg.header
+        self.pub_fov.publish(self.world)
+
+
+if __name__ == "__main__":
+    rospy.init_node("sonar_pointcloud")
+    rospy.on_shutdown(clean_up_mesh)
+
+    fov_publisher = SonarFOV()
+    rospy.spin()

--- a/scripts/sonar_pointcloud.py
+++ b/scripts/sonar_pointcloud.py
@@ -30,7 +30,8 @@ class SonarTranslator(object):
         self.elev_steps = rospy.get_param("~elev_steps", 2)
         self.min_elev = np.radians(min_elev_deg)
         self.max_elev = np.radians(max_elev_deg)
-        self.elevations = np.linspace(self.min_elev, self.max_elev, self.elev_steps)
+        self.elevations = np.linspace(
+            self.min_elev, self.max_elev, self.elev_steps)
 
         # threshold range is a float, [0-1]
         self.intensity_threshold = rospy.get_param("~intensity_threshold",
@@ -175,7 +176,7 @@ class SonarTranslator(object):
                                 fields=fields,
                                 point_step=28,
                                 row_step=28 * N,
-                                data=self.output_points.tostring())
+                                data=self.output_points.tobytes())
 
         dt1 = time.time() - t1
         dt0 = t1 - t0

--- a/scripts/sonar_pointcloud.py
+++ b/scripts/sonar_pointcloud.py
@@ -30,8 +30,8 @@ class SonarTranslator(object):
         self.elev_steps = rospy.get_param("~elev_steps", 2)
         self.min_elev = np.radians(min_elev_deg)
         self.max_elev = np.radians(max_elev_deg)
-        self.elevations = np.linspace(
-            self.min_elev, self.max_elev, self.elev_steps)
+        self.elevations = np.linspace(self.min_elev, self.max_elev,
+                                      self.elev_steps)
 
         # threshold range is a float, [0-1]
         self.intensity_threshold = rospy.get_param("~intensity_threshold",


### PR DESCRIPTION
## Publishing Sonar FOV as a Marker Array

### Goal/Background
An issue arose while using the `sonar_poincloud.py` utility to troubleshoot the sonar FOV. 

We currently publish "slices" of points corresponding to the sonar FOV, where each point is colored based on the return value from the sonar. Here's the point cloud with 2 slices:

![image](https://user-images.githubusercontent.com/97049012/202524272-398642a5-d0c1-4f92-acf6-b533c0362748.png)

This image actually shows the lag in generation, the oculus is at nearly 0-deg but the returned cloud is quite far behind.
This results in many, many points and it can be very difficult to see which points have a positive return value and which are zeroes. I had tried to simply set the alpha channel of the values that were 0 to 0, but rviz does not care about the published alpha channel (see [pointcloud documentation](http://wiki.ros.org/rviz/DisplayTypes/PointCloud), [issue here](https://github.com/ros-visualization/rviz/issues/166), and [issue here](https://github.com/ros-visualization/rviz/issues/64)). Even had this worked, it doesn't solve the issue of number of points.

During a discussion with @lauralindzey, she suggested splitting the troubleshooting into two options:
* A mesh showing the sonar current FOV with a set alpha value and no support for sonar return values
* A point cloud only showing positive return values.

This PR is the first half of that implementation.

### Implementation
This PR adds a new node, `sonar_fov.py` that subscribes to a /sonar_image and publishes a MarkerArray. 
The node procedurally generates a mesh corresponding to the FOV of the sonar with the current configuration (frequency, range). Rviz loads that mesh as a triangle list (which is a list of three vectors defining a surface triangle) to generate the visuals. 

The mesh isn't perfect (I haven't generated the arc points along the elevation) but I think it works well for quick analysis of FOV.
![image](https://user-images.githubusercontent.com/97049012/202739681-2e6e4aa8-10a7-4ef2-a41f-04859a2f0761.png)

This solution is:
* easier to see-through
* fully encompasses the FOV as opposed to user-selected slices of returns
* is much faster to generate and render in RVIZ
* Pulls parameters directly from the sonar image message as opposed to user defined values.

### Results
Here are some videos showing the implementation.
**Bag played back at half speed:**
https://user-images.githubusercontent.com/97049012/202525681-275c750a-1ece-4f88-ad29-f06779c31efa.mp4

**Bag played back at full speed:**
https://user-images.githubusercontent.com/97049012/202525789-c2d4e597-1ad1-42c7-80f9-f9985a6b3746.mp4

At full speed it's pretty clear how bad the point cloud lags.

**Bag with only the mesh**
https://user-images.githubusercontent.com/97049012/202554446-85119c67-ffe0-4aea-a4b0-2cacb458e728.mp4

**Only mesh, fixed transparency issues**
https://user-images.githubusercontent.com/97049012/202739634-f3a761a4-1b09-4eb4-aa64-87808bad7ffe.mp4

