### PR TITLE
MWE of using pre-commit to manage pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-json
+    -   id: check-xml
+    -   id: check-added-large-files
+    -   id: mixed-line-ending
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v15.0.4
+    hooks:
+    -   id: clang-format
+        # Respect .clang-format if it exists, otherwise use Google
+        args: ["--fallback-style=Google"]
+#
+# Uncomment the following to enable cpplint
+#
+#-   repo: https://gitlab.com/daverona/pre-commit/cpp
+#    rev: 0.8.0
+#    hooks:
+#    -   id: cpplint

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sonar_image_proc
 
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+
 Code to draw data from forward-looking imaging sonars.
 
 If built for ROS, it will build a node/nodelet


### PR DESCRIPTION
A first-cut MWE of using [pre-commit](https://pre-commit.com/) to manage Git pre-commit hooks.

To "activate" pre-commit on **your** checkout, you need to:

1.  Install the Python package e.g. `pip install pre-commit`
1. In your checkout, `pre-commit install` 

To manually check all files:  `pre-commit run --all-files`, otherwise the checks will run (duh) pre-commit.

**Note:** that many of the checks (e.g. clang) will update your files automatically.  It is up to you to commit the resulting changes.

---

The config file included here runs a number basic file heuristics (whitespace at the end of files, etc), and `clang-format` with the "Google" style.  

`cpplint` is included but commented out (using it will require the time commitment to fix the resulting warnings).

For reference, this is the output when I run it manually:


![Untitled](https://user-images.githubusercontent.com/122743/203163839-04e4f098-e1c5-4e8c-9e0a-8444d80839fa.jpg)
